### PR TITLE
Feat redirect to original link

### DIFF
--- a/server/README.md
+++ b/server/README.md
@@ -6,7 +6,7 @@
   - [x] It must not be possible to create a link with improperly formatted shortening
   - [x] It must not be possible to create a link with an already existing shortening
 - [x] It must be possible to delete a link
-- [ ] It must be possible to retrieve the original URL through the shortening
+- [x] It must be possible to retrieve the original URL through the shortening
 - [x] It must be possible to list all registered URLs
 - [ ] It must be possible to increment the number of accesses to a link
 - [ ] It must be possible to download a CSV with the report of the created links

--- a/server/src/app/functions/delete-shortened-link.spec.ts
+++ b/server/src/app/functions/delete-shortened-link.spec.ts
@@ -17,7 +17,7 @@ describe('Delete shortened link tests', () => {
     expect(deletedShortenedLinkInfo).toStrictEqual(shortenedLinkInfo);
   });
 
-  it('should not be able to delete a shortened link when id does not exist', async () => {
+  it('should not be able to delete a shortened link when shortened link does not exist', async () => {
     const sut = await deleteShortenedLink('1');
 
     expect(isLeft(sut)).toBeTruthy();

--- a/server/src/app/functions/delete-shortened-link.spec.ts
+++ b/server/src/app/functions/delete-shortened-link.spec.ts
@@ -8,7 +8,7 @@ describe('Delete shortened link tests', () => {
   it('should be able to delete a shortened link', async () => {
     const shortenedLinkInfo = await makeShortenedLink();
 
-    const sut = await deleteShortenedLink(shortenedLinkInfo.id);
+    const sut = await deleteShortenedLink(shortenedLinkInfo.shortenedLink);
 
     expect(isRight(sut)).toBeTruthy();
 

--- a/server/src/app/functions/delete-shortened-link.ts
+++ b/server/src/app/functions/delete-shortened-link.ts
@@ -13,13 +13,13 @@ type DeleteShortenedLinkOutput = {
 };
 
 export async function deleteShortenedLink(
-  id: string,
+  shortenedLink: string,
 ): Promise<Either<ShortenedLinkNotAvailable, DeleteShortenedLinkOutput>> {
   const shortenedLinksSchema = schema.shortenedLinks;
 
   const deletedInfo = await db
     .delete(shortenedLinksSchema)
-    .where(eq(shortenedLinksSchema.id, id))
+    .where(eq(shortenedLinksSchema.shortenedLink, shortenedLink))
     .returning();
 
   if (deletedInfo.length) {

--- a/server/src/app/functions/get-original-link.spec.ts
+++ b/server/src/app/functions/get-original-link.spec.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from 'vitest';
+import { getOriginalLink } from '@/app/functions/get-original-link';
+import { isLeft, isRight, unwrapEither } from '@/shared/either';
+import { ShortenedLinkNotAvailable } from '@/app/errors/shortened-link-not-available';
+import { makeShortenedLink } from '@/tests/factories/make-shortened-link';
+
+describe('Get original link tests', () => {
+  it('should be able to get the original link', async () => {
+    const shortenedLinkInfo = await makeShortenedLink();
+
+    const sut = await getOriginalLink(shortenedLinkInfo.shortenedLink);
+
+    expect(isRight(sut)).toBeTruthy();
+
+    const originalLink = unwrapEither(sut);
+
+    expect(originalLink).toStrictEqual({
+      originalLink: shortenedLinkInfo.originalLink,
+    });
+  });
+
+  it('should not be able to get the original link when shortened link does not exist', async () => {
+    const sut = await getOriginalLink('1');
+
+    expect(isLeft(sut)).toBeTruthy();
+
+    expect(unwrapEither(sut)).toBeInstanceOf(ShortenedLinkNotAvailable);
+  });
+});

--- a/server/src/app/functions/get-original-link.ts
+++ b/server/src/app/functions/get-original-link.ts
@@ -1,0 +1,22 @@
+import { ShortenedLinkNotAvailable } from '@/app/errors/shortened-link-not-available';
+import { db } from '@/infra/db';
+import { schema } from '@/infra/db/schemas';
+import { Either, makeLeft, makeRight } from '@/shared/either';
+import { eq } from 'drizzle-orm';
+
+export async function getOriginalLink(
+  shortenedLink: string,
+): Promise<Either<ShortenedLinkNotAvailable, { originalLink: string }>> {
+  const shortenedLinksSchema = schema.shortenedLinks;
+
+  const [shortenedLinkInfo] = await db
+    .select({ originalLink: shortenedLinksSchema.originalLink })
+    .from(shortenedLinksSchema)
+    .where(eq(shortenedLinksSchema.shortenedLink, shortenedLink));
+
+  if (!shortenedLinkInfo) {
+    return makeLeft(new ShortenedLinkNotAvailable());
+  }
+
+  return makeRight({ originalLink: shortenedLinkInfo.originalLink });
+}

--- a/server/src/infra/http/routes/delete-shortened-link.spec.ts
+++ b/server/src/infra/http/routes/delete-shortened-link.spec.ts
@@ -1,10 +1,8 @@
 import { afterAll, beforeAll, describe, expect, it } from 'vitest';
-import { randomUUID } from 'node:crypto';
 import { server } from '@/infra/http/server';
-import { db } from '@/infra/db';
-import { schema } from '@/infra/db/schemas';
+import { makeShortenedLink } from '@/tests/factories/make-shortened-link';
 
-describe('Delete shortened link route', () => {
+describe('Delete shortened link route tests', () => {
   beforeAll(async () => {
     await server.ready();
   });
@@ -14,12 +12,7 @@ describe('Delete shortened link route', () => {
   });
 
   it('should return 204 when delete a shortened link', async () => {
-    const shortenedLink = randomUUID().replaceAll('-', '');
-
-    await db
-      .insert(schema.shortenedLinks)
-      .values({ originalLink: 'https://test.com', shortenedLink })
-      .returning();
+    const { shortenedLink } = await makeShortenedLink();
 
     const response = await server.inject({
       method: 'DELETE',

--- a/server/src/infra/http/routes/delete-shortened-link.spec.ts
+++ b/server/src/infra/http/routes/delete-shortened-link.spec.ts
@@ -16,14 +16,14 @@ describe('Delete shortened link route', () => {
   it('should return 204 when delete a shortened link', async () => {
     const shortenedLink = randomUUID().replaceAll('-', '');
 
-    const [shortenedLinkInfo] = await db
+    await db
       .insert(schema.shortenedLinks)
       .values({ originalLink: 'https://test.com', shortenedLink })
       .returning();
 
     const response = await server.inject({
       method: 'DELETE',
-      url: `/shortened-links/${shortenedLinkInfo.id}`,
+      url: `/shortened-links/${shortenedLink}`,
     });
 
     expect(response.statusCode).toBe(204);

--- a/server/src/infra/http/routes/delete-shortened-link.ts
+++ b/server/src/infra/http/routes/delete-shortened-link.ts
@@ -7,13 +7,13 @@ export const deleteShortenedLinkRoute: FastifyPluginAsyncZod = async (
   server,
 ) => {
   server.delete(
-    '/shortened-links/:id',
+    '/shortened-links/:shortenedLink',
     {
       schema: {
         summary: 'Delete shortened link',
         tags: ['Shortened Links'],
         params: z.object({
-          id: z.string().describe('Shortened link ID'),
+          shortenedLink: z.string(),
         }),
         response: {
           204: z
@@ -22,15 +22,15 @@ export const deleteShortenedLinkRoute: FastifyPluginAsyncZod = async (
           404: z
             .object({ message: z.string() })
             .describe(
-              'No shortened link was found for the ID provided in the URL path.',
+              'No shortened link was found for the shortened link provided in the URL path.',
             ),
         },
       },
     },
     async (request, reply) => {
-      const { id } = request.params;
+      const { shortenedLink } = request.params;
 
-      const result = await deleteShortenedLink(id);
+      const result = await deleteShortenedLink(shortenedLink);
 
       if (isRight(result)) {
         return reply.status(204).send();

--- a/server/src/infra/http/routes/get-original-link.spec.ts
+++ b/server/src/infra/http/routes/get-original-link.spec.ts
@@ -1,0 +1,39 @@
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import { server } from '@/infra/http/server';
+import { makeShortenedLink } from '@/tests/factories/make-shortened-link';
+
+describe('Get original link route tests', () => {
+  beforeAll(async () => {
+    await server.ready();
+  });
+
+  afterAll(async () => {
+    await server.close();
+  });
+
+  it('should return 200 with original link when get the original link', async () => {
+    const { shortenedLink, originalLink } = await makeShortenedLink();
+
+    const response = await server.inject({
+      method: 'GET',
+      url: `/shortened-links/${shortenedLink}/original-link`,
+    });
+
+    const jsonResponse = response.json();
+
+    expect(response.statusCode).toBe(200);
+    expect(jsonResponse.originalLink).toBe(originalLink);
+  });
+
+  it('should return 404 when trying to get the original link that does not exist', async () => {
+    const response = await server.inject({
+      method: 'GET',
+      url: '/shortened-links/1/original-link',
+    });
+
+    const jsonResponse = response.json();
+
+    expect(response.statusCode).toBe(404);
+    expect(jsonResponse.message).toBe('Shortened link does not exist');
+  });
+});

--- a/server/src/infra/http/routes/get-original-link.ts
+++ b/server/src/infra/http/routes/get-original-link.ts
@@ -1,0 +1,51 @@
+import { getOriginalLink } from '@/app/functions/get-original-link';
+import { isRight, unwrapEither } from '@/shared/either';
+import { FastifyPluginAsyncZod } from 'fastify-type-provider-zod';
+import { z } from 'zod';
+
+export const getOriginalLinkRoute: FastifyPluginAsyncZod = async (server) => {
+  server.get(
+    '/shortened-links/:shortenedLink/original-link',
+    {
+      schema: {
+        summary: 'Get original link from shortened link',
+        tags: ['Shortened Links'],
+        params: z.object({
+          shortenedLink: z.string(),
+        }),
+        response: {
+          200: z
+            .object({
+              originalLink: z.string(),
+            })
+            .describe(
+              'Returns the original link corresponding to the shortened link.',
+            ),
+          404: z
+            .object({ message: z.string() })
+            .describe(
+              'No original link was found for the shortened link provided in the URL path.',
+            ),
+        },
+      },
+    },
+    async (request, reply) => {
+      const { shortenedLink } = request.params;
+
+      const result = await getOriginalLink(shortenedLink);
+
+      if (isRight(result)) {
+        const { originalLink } = unwrapEither(result);
+
+        return reply.status(200).send({ originalLink });
+      }
+
+      const error = unwrapEither(result);
+
+      switch (error.constructor.name) {
+        case 'ShortenedLinkNotAvailable':
+          return reply.status(404).send({ message: error.message });
+      }
+    },
+  );
+};

--- a/server/src/infra/http/routes/get-shortened-links.ts
+++ b/server/src/infra/http/routes/get-shortened-links.ts
@@ -15,20 +15,22 @@ export const getShortenedLinksRoute: FastifyPluginAsyncZod = async (server) => {
           pageSize: z.coerce.number().min(1).optional().default(20),
         }),
         response: {
-          200: z.object({
-            total: z.number(),
-            page: z.number(),
-            pageSize: z.number(),
-            data: z.array(
-              z.object({
-                id: z.string(),
-                originalLink: z.string(),
-                shortenedLink: z.string(),
-                quantityAccesses: z.number(),
-                createdAt: z.date(),
-              }),
-            ),
-          }),
+          200: z
+            .object({
+              total: z.number(),
+              page: z.number(),
+              pageSize: z.number(),
+              data: z.array(
+                z.object({
+                  id: z.string(),
+                  originalLink: z.string(),
+                  shortenedLink: z.string(),
+                  quantityAccesses: z.number(),
+                  createdAt: z.date(),
+                }),
+              ),
+            })
+            .describe('List of links with pagination'),
         },
       },
     },

--- a/server/src/infra/http/routes/get-shortened-links.ts
+++ b/server/src/infra/http/routes/get-shortened-links.ts
@@ -3,9 +3,7 @@ import { unwrapEither } from '@/shared/either';
 import { FastifyPluginAsyncZod } from 'fastify-type-provider-zod';
 import { z } from 'zod';
 
-export const getShortenedLinksRoutes: FastifyPluginAsyncZod = async (
-  server,
-) => {
+export const getShortenedLinksRoute: FastifyPluginAsyncZod = async (server) => {
   server.get(
     '/shortened-links',
     {

--- a/server/src/infra/http/server.ts
+++ b/server/src/infra/http/server.ts
@@ -12,7 +12,7 @@ import { env } from '@/env';
 import { healthCheckRoute } from '@/infra/http/routes/health-check';
 import { createShortenedLinkRoute } from '@/infra/http/routes/create-shortened-link';
 import { deleteShortenedLinkRoute } from '@/infra/http/routes/delete-shortened-link';
-import { getShortenedLinksRoutes } from '@/infra/http/routes/get-shortened-links';
+import { getShortenedLinksRoute } from '@/infra/http/routes/get-shortened-links';
 
 const server = fastify();
 
@@ -59,7 +59,7 @@ server.register(healthCheckRoute);
 
 server.register(createShortenedLinkRoute);
 server.register(deleteShortenedLinkRoute);
-server.register(getShortenedLinksRoutes);
+server.register(getShortenedLinksRoute);
 
 if (process.env.NODE_ENV !== 'test') {
   server.listen({ port: env.PORT, host: '0.0.0.0' }).then(() => {

--- a/server/src/infra/http/server.ts
+++ b/server/src/infra/http/server.ts
@@ -13,6 +13,7 @@ import { healthCheckRoute } from '@/infra/http/routes/health-check';
 import { createShortenedLinkRoute } from '@/infra/http/routes/create-shortened-link';
 import { deleteShortenedLinkRoute } from '@/infra/http/routes/delete-shortened-link';
 import { getShortenedLinksRoute } from '@/infra/http/routes/get-shortened-links';
+import { getOriginalLinkRoute } from '@/infra/http/routes/get-original-link';
 
 const server = fastify();
 
@@ -60,6 +61,7 @@ server.register(healthCheckRoute);
 server.register(createShortenedLinkRoute);
 server.register(deleteShortenedLinkRoute);
 server.register(getShortenedLinksRoute);
+server.register(getOriginalLinkRoute);
 
 if (process.env.NODE_ENV !== 'test') {
   server.listen({ port: env.PORT, host: '0.0.0.0' }).then(() => {

--- a/web/README.md
+++ b/web/README.md
@@ -6,7 +6,7 @@
   - [x] It must not be possible to create a link with improperly formatted shortening
   - [x] It must not be possible to create a link with an already existing shortening
 - [x] It must be possible to delete a link
-- [ ] It must be possible to retrieve the original URL through the shortening
+- [x] It must be possible to retrieve the original URL through the shortening
 - [x] It must be possible to list all registered URLs
 - [ ] It must be possible to increment the number of accesses to a link
 - [ ] It must be possible to download a CSV with the report of the created links

--- a/web/src/pages/Home/components/MyLinks/Link/index.spec.tsx
+++ b/web/src/pages/Home/components/MyLinks/Link/index.spec.tsx
@@ -87,7 +87,7 @@ describe('Link tests', () => {
   });
 
   it('should delete the link', async () => {
-    apiMock.onDelete('/shortened-links/123').reply(200);
+    apiMock.onDelete('/shortened-links/test').reply(200);
 
     queryClient.refetchQueries = vi.fn();
 
@@ -113,7 +113,7 @@ describe('Link tests', () => {
     await waitFor(() => {
       expect(
         apiMock.history.delete.some(
-          ({ url }) => url === '/shortened-links/123',
+          ({ url }) => url === '/shortened-links/test',
         ),
       ).toBeTruthy();
     });
@@ -131,7 +131,7 @@ describe('Link tests', () => {
   });
 
   it('should display toast error when deletion fails', async () => {
-    apiMock.onDelete('/shortened-links/123').reply(400);
+    apiMock.onDelete('/shortened-links/test').reply(400);
 
     render(<Link isFirstLink={false} info={linkInfo} />);
 
@@ -142,7 +142,7 @@ describe('Link tests', () => {
     await waitFor(() => {
       expect(
         apiMock.history.delete.some(
-          ({ url }) => url === '/shortened-links/123',
+          ({ url }) => url === '/shortened-links/test',
         ),
       ).toBeTruthy();
     });

--- a/web/src/pages/Home/components/MyLinks/Link/index.tsx
+++ b/web/src/pages/Home/components/MyLinks/Link/index.tsx
@@ -44,7 +44,7 @@ export const Link: React.FC<LinkProps> = ({
     setIsDeleting(true);
 
     try {
-      await api.delete(`/shortened-links/${id}`);
+      await api.delete(`/shortened-links/${shortenedLink}`);
 
       queryClient.refetchQueries({ queryKey: ['links list'], exact: true });
 

--- a/web/src/pages/Home/components/MyLinks/__snapshots__/index.spec.tsx.snap
+++ b/web/src/pages/Home/components/MyLinks/__snapshots__/index.spec.tsx.snap
@@ -87,7 +87,7 @@ exports[`My Links testes > should render correctly when it is loading list of li
         <p
           class="text-xs text-gray-500 uppercase text-center"
         >
-          Carregando...
+          Carregando links...
         </p>
       </div>
     </div>

--- a/web/src/pages/Home/components/MyLinks/index.tsx
+++ b/web/src/pages/Home/components/MyLinks/index.tsx
@@ -95,7 +95,7 @@ export const MyLinks: React.FC = () => {
         ) : !listOfLinks ? (
           <EmptyState
             icon={<Spinner />}
-            description="Carregando..."
+            description="Carregando links..."
             data-testid="container-link-list-loading"
           />
         ) : listOfLinksIsEmpty ? (

--- a/web/src/pages/Redirect/index.tsx
+++ b/web/src/pages/Redirect/index.tsx
@@ -1,8 +1,46 @@
-import React from 'react';
+import React, { useEffect } from 'react';
 
+import { useLocation, useNavigate } from 'react-router';
+import { api } from '@/service/api';
 import logoIcon from '@/assets/logo-icon.svg';
+import { AxiosError } from 'axios';
+
+type GetOriginalLinkOutput = {
+  originalLink: string;
+};
 
 export const Redirect: React.FC = () => {
+  const { pathname } = useLocation();
+  const navigate = useNavigate();
+
+  useEffect(() => {
+    const getOriginalLink = async (): Promise<void> => {
+      try {
+        const { data } = await api.get<GetOriginalLinkOutput>(
+          `/shortened-links/${pathname.slice(1)}/original-link`,
+        );
+
+        let url = data.originalLink;
+
+        if (url.startsWith('www.')) {
+          url = `https://${url}`;
+        }
+
+        window.location.href = url;
+      } catch (error) {
+        const err = error as AxiosError;
+
+        if (err.status === 404) {
+          navigate('/url/not-found');
+        }
+      }
+    };
+
+    if (pathname) {
+      getOriginalLink();
+    }
+  }, [pathname, navigate]);
+
   return (
     <main
       className="w-screen min-h-screen flex flex-row items-center justify-center p-6 bg-gray-200"

--- a/web/src/routes/index.tsx
+++ b/web/src/routes/index.tsx
@@ -1,8 +1,10 @@
 import { RouteObject } from 'react-router';
 import { Home } from '@/pages/Home';
 import { NotFound } from '@/pages/NotFound';
+import { Redirect } from '@/pages/Redirect';
 
 export const routesConfig: RouteObject[] = [
   { path: '/', Component: Home },
+  { path: '/:shortened-link', Component: Redirect },
   { path: '*', Component: NotFound },
 ];

--- a/web/src/tests/routes.spec.tsx
+++ b/web/src/tests/routes.spec.tsx
@@ -8,7 +8,7 @@ import { routesConfig } from '@/routes';
 describe('Routes tests', () => {
   it('should render not found page when route does not exists', () => {
     const router = createMemoryRouter(routesConfig, {
-      initialEntries: ['/not-found'],
+      initialEntries: ['/not-found/route'],
     });
 
     render(<RouterProvider router={router} />);
@@ -33,5 +33,17 @@ describe('Routes tests', () => {
 
     expect(screen.queryByTestId('container-not-found')).not.toBeInTheDocument();
     expect(screen.getByTestId('container-home-page')).toBeInTheDocument();
+  });
+
+  it('should render redirect page', () => {
+    const router = createMemoryRouter(routesConfig, {
+      initialEntries: ['/shortened-link'],
+    });
+
+    render(<RouterProvider router={router} />);
+
+    expect(screen.queryByTestId('container-home-page')).not.toBeInTheDocument();
+    expect(screen.queryByTestId('container-not-found')).not.toBeInTheDocument();
+    expect(screen.getByTestId('container-redirect-page')).toBeInTheDocument();
   });
 });


### PR DESCRIPTION
- Updated the delete shortened link endpoint to use the shortened link as the identifier.
- Implemented the `GET /shortened-links/:shortenedLink/original-link` endpoint to get the original link from a shortened link.
- Implemented the redirect page