### PR TITLE
Feat increment number accesses

### DIFF
--- a/server/README.md
+++ b/server/README.md
@@ -8,7 +8,7 @@
 - [x] It must be possible to delete a link
 - [x] It must be possible to retrieve the original URL through the shortening
 - [x] It must be possible to list all registered URLs
-- [ ] It must be possible to increment the number of accesses to a link
+- [x] It must be possible to increment the number of accesses to a link
 - [ ] It must be possible to download a CSV with the report of the created links
   - [ ] It must be possible to access the CSV via a CDN (Amazon S3, Cloudflare R2, etc.)
   - [ ] A random and unique name must be generated for the file

--- a/server/src/app/functions/update-access-quantity.spec.ts
+++ b/server/src/app/functions/update-access-quantity.spec.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it } from 'vitest';
+import { isLeft, isRight, unwrapEither } from '@/shared/either';
+import { ShortenedLinkNotAvailable } from '@/app/errors/shortened-link-not-available';
+import { makeShortenedLink } from '@/tests/factories/make-shortened-link';
+import { updateAccessQuantity } from '@/app/functions/update-access-quantity';
+
+describe('Update access quantity tests', () => {
+  it('should be able to update access quantity', async () => {
+    const shortenedLinkInfo = await makeShortenedLink();
+
+    const sut = await updateAccessQuantity(shortenedLinkInfo.shortenedLink);
+
+    expect(isRight(sut)).toBeTruthy();
+
+    const result = unwrapEither(sut);
+
+    expect(result).toStrictEqual({
+      originalLink: shortenedLinkInfo.originalLink,
+      shortenedLink: shortenedLinkInfo.shortenedLink,
+      quantityAccesses: 1,
+    });
+  });
+
+  it('should not be able to update access quantity when shortened link does not exist', async () => {
+    const sut = await updateAccessQuantity('1');
+
+    expect(isLeft(sut)).toBeTruthy();
+
+    expect(unwrapEither(sut)).toBeInstanceOf(ShortenedLinkNotAvailable);
+  });
+});

--- a/server/src/app/functions/update-access-quantity.ts
+++ b/server/src/app/functions/update-access-quantity.ts
@@ -1,0 +1,35 @@
+import { ShortenedLinkNotAvailable } from '@/app/errors/shortened-link-not-available';
+import { db } from '@/infra/db';
+import { schema } from '@/infra/db/schemas';
+import { Either, makeLeft, makeRight } from '@/shared/either';
+import { eq, sql } from 'drizzle-orm';
+
+type UpdateAccessQuantityOutput = {
+  originalLink: string;
+  shortenedLink: string;
+  quantityAccesses: number;
+};
+
+export async function updateAccessQuantity(
+  shortenedLink: string,
+): Promise<Either<ShortenedLinkNotAvailable, UpdateAccessQuantityOutput>> {
+  const shortenedLinksSchema = schema.shortenedLinks;
+
+  const [shortenedLinkInfo] = await db
+    .update(shortenedLinksSchema)
+    .set({
+      quantityAccesses: sql`${shortenedLinksSchema.quantityAccesses} + 1`,
+    })
+    .where(eq(shortenedLinksSchema.shortenedLink, shortenedLink))
+    .returning({
+      originalLink: shortenedLinksSchema.originalLink,
+      shortenedLink: shortenedLinksSchema.shortenedLink,
+      quantityAccesses: shortenedLinksSchema.quantityAccesses,
+    });
+
+  if (!shortenedLinkInfo) {
+    return makeLeft(new ShortenedLinkNotAvailable());
+  }
+
+  return makeRight(shortenedLinkInfo);
+}

--- a/server/src/infra/http/routes/update-access-quantity.spec.ts
+++ b/server/src/infra/http/routes/update-access-quantity.spec.ts
@@ -1,0 +1,41 @@
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import { server } from '@/infra/http/server';
+import { makeShortenedLink } from '@/tests/factories/make-shortened-link';
+
+describe('Update access quantity route tests', () => {
+  beforeAll(async () => {
+    await server.ready();
+  });
+
+  afterAll(async () => {
+    await server.close();
+  });
+
+  it('should return 200 when get update access quantity', async () => {
+    const { shortenedLink, originalLink } = await makeShortenedLink();
+
+    const response = await server.inject({
+      method: 'PATCH',
+      url: `/shortened-links/${shortenedLink}/access`,
+    });
+
+    const jsonResponse = response.json();
+
+    expect(response.statusCode).toBe(200);
+    expect(jsonResponse.originalLink).toBe(originalLink);
+    expect(jsonResponse.shortenedLink).toBe(shortenedLink);
+    expect(jsonResponse.quantityAccesses).toBe(1);
+  });
+
+  it('should return 404 when trying to update access quantity of shortened link that does not exist', async () => {
+    const response = await server.inject({
+      method: 'PATCH',
+      url: '/shortened-links/1/access',
+    });
+
+    const jsonResponse = response.json();
+
+    expect(response.statusCode).toBe(404);
+    expect(jsonResponse.message).toBe('Shortened link does not exist');
+  });
+});

--- a/server/src/infra/http/routes/update-access-quantity.ts
+++ b/server/src/infra/http/routes/update-access-quantity.ts
@@ -1,0 +1,58 @@
+import { updateAccessQuantity } from '@/app/functions/update-access-quantity';
+import { isRight, unwrapEither } from '@/shared/either';
+import { FastifyPluginAsyncZod } from 'fastify-type-provider-zod';
+import { z } from 'zod';
+
+export const updateAccessQuantityRoute: FastifyPluginAsyncZod = async (
+  server,
+) => {
+  server.patch(
+    '/shortened-links/:shortenedLink/access',
+    {
+      schema: {
+        summary: 'Update access quantity',
+        tags: ['Shortened Links'],
+        params: z.object({
+          shortenedLink: z.string(),
+        }),
+        response: {
+          200: z
+            .object({
+              originalLink: z.string(),
+              shortenedLink: z.string(),
+              quantityAccesses: z.number(),
+            })
+            .describe(
+              'Successfully incremented the access count for the shortened link.',
+            ),
+          404: z
+            .object({ message: z.string() })
+            .describe(
+              'No original link was found for the shortened link provided in the URL path.',
+            ),
+        },
+      },
+    },
+    async (request, reply) => {
+      const { shortenedLink } = request.params;
+
+      const result = await updateAccessQuantity(shortenedLink);
+
+      if (isRight(result)) {
+        const { originalLink, shortenedLink, quantityAccesses } =
+          unwrapEither(result);
+
+        return reply
+          .status(200)
+          .send({ originalLink, shortenedLink, quantityAccesses });
+      }
+
+      const error = unwrapEither(result);
+
+      switch (error.constructor.name) {
+        case 'ShortenedLinkNotAvailable':
+          return reply.status(404).send({ message: error.message });
+      }
+    },
+  );
+};

--- a/server/src/infra/http/server.ts
+++ b/server/src/infra/http/server.ts
@@ -35,7 +35,7 @@ server.setErrorHandler((error, _, reply) => {
 
 server.register(fastifyCors, {
   origin: '*',
-  methods: ['GET', 'POST', 'PUT', 'DELETE', 'OPTIONS'],
+  methods: ['GET', 'POST', 'PUT', 'PATCH', 'DELETE', 'OPTIONS'],
 });
 
 server.register(fastifySwagger, {

--- a/server/src/infra/http/server.ts
+++ b/server/src/infra/http/server.ts
@@ -14,6 +14,7 @@ import { createShortenedLinkRoute } from '@/infra/http/routes/create-shortened-l
 import { deleteShortenedLinkRoute } from '@/infra/http/routes/delete-shortened-link';
 import { getShortenedLinksRoute } from '@/infra/http/routes/get-shortened-links';
 import { getOriginalLinkRoute } from '@/infra/http/routes/get-original-link';
+import { updateAccessQuantityRoute } from '@/infra/http/routes/update-access-quantity';
 
 const server = fastify();
 
@@ -62,6 +63,7 @@ server.register(createShortenedLinkRoute);
 server.register(deleteShortenedLinkRoute);
 server.register(getShortenedLinksRoute);
 server.register(getOriginalLinkRoute);
+server.register(updateAccessQuantityRoute);
 
 if (process.env.NODE_ENV !== 'test') {
   server.listen({ port: env.PORT, host: '0.0.0.0' }).then(() => {

--- a/web/README.md
+++ b/web/README.md
@@ -8,5 +8,5 @@
 - [x] It must be possible to delete a link
 - [x] It must be possible to retrieve the original URL through the shortening
 - [x] It must be possible to list all registered URLs
-- [ ] It must be possible to increment the number of accesses to a link
+- [x] It must be possible to increment the number of accesses to a link
 - [ ] It must be possible to download a CSV with the report of the created links

--- a/web/src/app.tsx
+++ b/web/src/app.tsx
@@ -1,14 +1,27 @@
-import React from 'react';
+import React, { useEffect } from 'react';
 
 import { createBrowserRouter, RouterProvider } from 'react-router';
 import { QueryClientProvider } from '@tanstack/react-query';
 import { ReactQueryDevtools } from '@tanstack/react-query-devtools';
 import { routesConfig } from '@/routes';
 import { queryClient } from '@/service/queryClient';
+import { refetchChannel } from '@/service/broadcastChannel';
 
 const router = createBrowserRouter(routesConfig);
 
 export const App: React.FC = () => {
+  useEffect(() => {
+    const onMessage = (event: MessageEvent): void => {
+      queryClient.refetchQueries(event.data);
+    };
+
+    refetchChannel.onmessage = onMessage;
+
+    return (): void => {
+      refetchChannel.onmessage = null;
+    };
+  }, []);
+
   return (
     <QueryClientProvider client={queryClient}>
       <RouterProvider router={router} />

--- a/web/src/components/Toast/index.tsx
+++ b/web/src/components/Toast/index.tsx
@@ -24,8 +24,8 @@ export const Toast: React.FC<ToastProps> = ({
 }) => {
   const color = type === 'error' ? 'danger' : 'blue-base';
 
-  const textColor = `text-${color}`;
-  const backgroundColor = type === 'error' ? '#f1d4da' : '#d6d8ef';
+  const textColor = type === 'error' ? 'text-danger' : 'text-blue-base';
+  const backgroundColor = type === 'error' ? 'bg-[#f1d4da]' : 'bg-[#d6d8ef]';
 
   return (
     <ToastRadix.Provider swipeDirection="right">
@@ -33,7 +33,7 @@ export const Toast: React.FC<ToastProps> = ({
         open={open}
         onOpenChange={onOpenChange}
         duration={duration}
-        className={`max-w-[94vw] w-180 flex flex-row gap-6 items-start justify-start bg-[${backgroundColor}] p-8 rounded-lg shadow-lg shadow-gray-300`}
+        className={`max-w-[94vw] w-180 flex flex-row gap-6 items-start justify-start ${backgroundColor} p-8 rounded-lg shadow-lg shadow-gray-300`}
         data-testid={id}
       >
         <WarningCircle

--- a/web/src/pages/Home/components/MyLinks/Link/__snapshots__/index.spec.tsx.snap
+++ b/web/src/pages/Home/components/MyLinks/Link/__snapshots__/index.spec.tsx.snap
@@ -14,6 +14,8 @@ exports[`Link tests > should render correctly when it is first link 1`] = `
         class="text-md text-blue-base truncate"
         data-testid="link-shortened-link"
         href="/test"
+        rel="noreferrer"
+        target="_blank"
       >
         brev.ly/
         test
@@ -171,6 +173,8 @@ exports[`Link tests > should render correctly when it is not first link 1`] = `
         class="text-md text-blue-base truncate"
         data-testid="link-shortened-link"
         href="/test"
+        rel="noreferrer"
+        target="_blank"
       >
         brev.ly/
         test

--- a/web/src/pages/Home/components/MyLinks/Link/__snapshots__/index.spec.tsx.snap
+++ b/web/src/pages/Home/components/MyLinks/Link/__snapshots__/index.spec.tsx.snap
@@ -78,26 +78,30 @@ exports[`Link tests > should render correctly when it is first link 1`] = `
     </div>
   </div>
   <div
-    aria-label="Notifications (F8)"
-    role="region"
-    style="pointer-events: none;"
-    tabindex="-1"
+    class="fixed z-3"
   >
-    <ol
-      class="z-3 fixed bottom-6 left-1/2 transform -translate-x-1/2 md:bottom-12 md:right-12 md:left-auto md:transform-none md:translate-x-0"
+    <div
+      aria-label="Notifications (F8)"
+      role="region"
+      style="pointer-events: none;"
       tabindex="-1"
-    />
-  </div>
-  <div
-    aria-label="Notifications (F8)"
-    role="region"
-    style="pointer-events: none;"
-    tabindex="-1"
-  >
-    <ol
-      class="z-3 fixed bottom-6 left-1/2 transform -translate-x-1/2 md:bottom-12 md:right-12 md:left-auto md:transform-none md:translate-x-0"
+    >
+      <ol
+        class="z-3 fixed bottom-6 left-1/2 transform -translate-x-1/2 md:bottom-12 md:right-12 md:left-auto md:transform-none md:translate-x-0"
+        tabindex="-1"
+      />
+    </div>
+    <div
+      aria-label="Notifications (F8)"
+      role="region"
+      style="pointer-events: none;"
       tabindex="-1"
-    />
+    >
+      <ol
+        class="z-3 fixed bottom-6 left-1/2 transform -translate-x-1/2 md:bottom-12 md:right-12 md:left-auto md:transform-none md:translate-x-0"
+        tabindex="-1"
+      />
+    </div>
   </div>
 </div>
 `;
@@ -135,26 +139,30 @@ exports[`Link tests > should render correctly when it is loading 1`] = `
     </div>
   </div>
   <div
-    aria-label="Notifications (F8)"
-    role="region"
-    style="pointer-events: none;"
-    tabindex="-1"
+    class="fixed z-3"
   >
-    <ol
-      class="z-3 fixed bottom-6 left-1/2 transform -translate-x-1/2 md:bottom-12 md:right-12 md:left-auto md:transform-none md:translate-x-0"
+    <div
+      aria-label="Notifications (F8)"
+      role="region"
+      style="pointer-events: none;"
       tabindex="-1"
-    />
-  </div>
-  <div
-    aria-label="Notifications (F8)"
-    role="region"
-    style="pointer-events: none;"
-    tabindex="-1"
-  >
-    <ol
-      class="z-3 fixed bottom-6 left-1/2 transform -translate-x-1/2 md:bottom-12 md:right-12 md:left-auto md:transform-none md:translate-x-0"
+    >
+      <ol
+        class="z-3 fixed bottom-6 left-1/2 transform -translate-x-1/2 md:bottom-12 md:right-12 md:left-auto md:transform-none md:translate-x-0"
+        tabindex="-1"
+      />
+    </div>
+    <div
+      aria-label="Notifications (F8)"
+      role="region"
+      style="pointer-events: none;"
       tabindex="-1"
-    />
+    >
+      <ol
+        class="z-3 fixed bottom-6 left-1/2 transform -translate-x-1/2 md:bottom-12 md:right-12 md:left-auto md:transform-none md:translate-x-0"
+        tabindex="-1"
+      />
+    </div>
   </div>
 </div>
 `;
@@ -237,26 +245,30 @@ exports[`Link tests > should render correctly when it is not first link 1`] = `
     </div>
   </div>
   <div
-    aria-label="Notifications (F8)"
-    role="region"
-    style="pointer-events: none;"
-    tabindex="-1"
+    class="fixed z-3"
   >
-    <ol
-      class="z-3 fixed bottom-6 left-1/2 transform -translate-x-1/2 md:bottom-12 md:right-12 md:left-auto md:transform-none md:translate-x-0"
+    <div
+      aria-label="Notifications (F8)"
+      role="region"
+      style="pointer-events: none;"
       tabindex="-1"
-    />
-  </div>
-  <div
-    aria-label="Notifications (F8)"
-    role="region"
-    style="pointer-events: none;"
-    tabindex="-1"
-  >
-    <ol
-      class="z-3 fixed bottom-6 left-1/2 transform -translate-x-1/2 md:bottom-12 md:right-12 md:left-auto md:transform-none md:translate-x-0"
+    >
+      <ol
+        class="z-3 fixed bottom-6 left-1/2 transform -translate-x-1/2 md:bottom-12 md:right-12 md:left-auto md:transform-none md:translate-x-0"
+        tabindex="-1"
+      />
+    </div>
+    <div
+      aria-label="Notifications (F8)"
+      role="region"
+      style="pointer-events: none;"
       tabindex="-1"
-    />
+    >
+      <ol
+        class="z-3 fixed bottom-6 left-1/2 transform -translate-x-1/2 md:bottom-12 md:right-12 md:left-auto md:transform-none md:translate-x-0"
+        tabindex="-1"
+      />
+    </div>
   </div>
 </div>
 `;

--- a/web/src/pages/Home/components/MyLinks/Link/index.tsx
+++ b/web/src/pages/Home/components/MyLinks/Link/index.tsx
@@ -101,7 +101,7 @@ export const Link: React.FC<LinkProps> = ({
             className="text-sm text-gray-500 whitespace-nowrap"
             data-testid="text-quantity-accesses"
           >
-            {quantityAccesses} acessos
+            {quantityAccesses ?? 0} acessos
           </p>
         )}
 
@@ -173,24 +173,26 @@ export const Link: React.FC<LinkProps> = ({
         </div>
       </div>
 
-      <Toast
-        id="toast-shortened-link-copied"
-        type="information"
-        title="Link copiado com sucesso"
-        description={`O link ${shortenedLink} foi copiado para a área de transferência`}
-        duration={3000}
-        open={linkCopied}
-        onOpenChange={setLinkCopied}
-      />
+      <div className="fixed z-3">
+        <Toast
+          id="toast-shortened-link-copied"
+          type="information"
+          title="Link copiado com sucesso"
+          description={`O link ${shortenedLink} foi copiado para a área de transferência`}
+          duration={3000}
+          open={linkCopied}
+          onOpenChange={setLinkCopied}
+        />
 
-      <Toast
-        id="toast-deletion-error"
-        type="error"
-        title="Erro ao deletar"
-        description="Por favor, tente novamente mais tarde."
-        open={deletionError}
-        onOpenChange={setDeletionError}
-      />
+        <Toast
+          id="toast-deletion-error"
+          type="error"
+          title="Erro ao deletar"
+          description="Por favor, tente novamente mais tarde."
+          open={deletionError}
+          onOpenChange={setDeletionError}
+        />
+      </div>
     </>
   );
 };

--- a/web/src/pages/Home/components/MyLinks/Link/index.tsx
+++ b/web/src/pages/Home/components/MyLinks/Link/index.tsx
@@ -73,6 +73,8 @@ export const Link: React.FC<LinkProps> = ({
           ) : (
             <a
               href={`/${shortenedLink}`}
+              target="_blank"
+              rel="noreferrer"
               className="text-md text-blue-base truncate"
               data-testid="link-shortened-link"
             >

--- a/web/src/pages/Home/components/MyLinks/index.tsx
+++ b/web/src/pages/Home/components/MyLinks/index.tsx
@@ -55,6 +55,7 @@ export const MyLinks: React.FC = () => {
 
       return undefined;
     },
+    refetchOnWindowFocus: true,
   });
 
   const onScroll = (event: React.UIEvent<HTMLDivElement>): void => {

--- a/web/src/pages/Redirect/index.spec.tsx
+++ b/web/src/pages/Redirect/index.spec.tsx
@@ -3,6 +3,7 @@ import { render, screen, waitFor } from '@testing-library/react';
 import AxiosMock from 'axios-mock-adapter';
 import { Redirect } from '@/pages/Redirect';
 import { api } from '@/service/api';
+import { queryClient } from '@/service/queryClient';
 
 const mockNavigate = vi.fn();
 
@@ -100,5 +101,26 @@ describe('Redirect page tests', () => {
     });
 
     expect(mockNavigate).toBeCalledWith('/url/not-found');
+  });
+
+  it('should update access quantity when access the page', async () => {
+    apiMock.onPatch('/shortened-links/test/access').reply(200);
+
+    queryClient.refetchQueries = vi.fn();
+
+    render(<Redirect />);
+
+    await waitFor(() => {
+      expect(
+        apiMock.history.patch.some(
+          ({ url }) => url === '/shortened-links/test/access',
+        ),
+      );
+    });
+
+    expect(queryClient.refetchQueries).toBeCalledWith({
+      queryKey: ['links list'],
+      exact: true,
+    });
   });
 });

--- a/web/src/service/broadcastChannel.ts
+++ b/web/src/service/broadcastChannel.ts
@@ -1,0 +1,1 @@
+export const refetchChannel = new BroadcastChannel('refetch-channel');


### PR DESCRIPTION
- Modified to open shortened links in a new tab.
- Implemented the `PATCH: /shortened-links/:shortenedLink/access` endpoint to increment the access count of a shortened link.
- Fixed the styling of the toast.
- Updated the access count of a shortened link during the redirection process.