### PR TITLE
Fix placeholder pointer events

### DIFF
--- a/web/src/components/Input/__snapshots__/index.spec.tsx.snap
+++ b/web/src/components/Input/__snapshots__/index.spec.tsx.snap
@@ -84,7 +84,7 @@ exports[`Input tests > should display input with fixed placeholder correctly 1`]
       type="text"
     />
     <span
-      class="absolute top-18.5 left-8.5 text-md text-gray-400 font-normal z-1"
+      class="absolute top-18.5 left-8.5 text-md text-gray-400 font-normal z-1 pointer-events-none"
       data-testid="input-test-fixed-placeholder"
     >
       Placeholder

--- a/web/src/components/Input/index.tsx
+++ b/web/src/components/Input/index.tsx
@@ -90,7 +90,7 @@ export const Input: React.FC<InputProps> = ({
       {fixedPlaceholder && (
         <span
           data-testid={`${id}-fixed-placeholder`}
-          className="absolute top-18.5 left-8.5 text-md text-gray-400 font-normal z-1"
+          className="absolute top-18.5 left-8.5 text-md text-gray-400 font-normal z-1 pointer-events-none"
         >
           {fixedPlaceholder}
         </span>

--- a/web/src/pages/Home/components/NewLink/__snapshots__/index.spec.tsx.snap
+++ b/web/src/pages/Home/components/NewLink/__snapshots__/index.spec.tsx.snap
@@ -48,7 +48,7 @@ exports[`New Link tests > should render correctly 1`] = `
           type="text"
         />
         <span
-          class="absolute top-18.5 left-8.5 text-md text-gray-400 font-normal z-1"
+          class="absolute top-18.5 left-8.5 text-md text-gray-400 font-normal z-1 pointer-events-none"
           data-testid="input-shortened-link-fixed-placeholder"
         >
           brev.ly/


### PR DESCRIPTION
- Adjusted the `pointer-events` property to `none` for the fixed input placeholder to prevent it from interfering with user interactions.